### PR TITLE
Add interactive MiniPong play, pygame dependency, and multi-rally score_limit support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deps install-hooks lint typecheck test docker-build docker-smoke whitepapers-acquire whitepapers-verify env-smoke train-smoke eval-smoke verify-learning dashboard validate run-scenarios compile-feedback nfr-check factory-local factory-status
+.PHONY: deps install-hooks lint typecheck test docker-build docker-smoke whitepapers-acquire whitepapers-verify env-smoke train-smoke eval-smoke verify-learning dashboard play play-debug play-agent-vs-agent validate run-scenarios compile-feedback nfr-check factory-local factory-status
 
 deps:
 	pip-compile requirements.in
@@ -52,6 +52,17 @@ verify-learning:
 # ── Dashboard ────────────────────────────────────────────
 dashboard:
 	streamlit run src/dashboard/app.py
+
+
+# ── Interactive Play ─────────────────────────────────────
+play:
+	python -m src.play.play_minipong
+
+play-debug:
+	python -m src.play.play_minipong --debug
+
+play-agent-vs-agent:
+	python -m src.play.play_minipong --left-agent --right-agent
 
 # ── Validation ───────────────────────────────────────────
 validate: lint typecheck test docker-build docker-smoke env-smoke whitepapers-verify

--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,4 @@ matplotlib
 pandas
 pypdf
 requests
+pygame

--- a/src/envs/minipong.py
+++ b/src/envs/minipong.py
@@ -20,6 +20,7 @@ class MiniPongConfig:
     ball_size: int = 3
     max_steps: int = 1200
     reward_shaping: bool = False
+    score_limit: int = 1
 
 
 class MiniPongEnv(gym.Env[np.ndarray, int]):
@@ -45,6 +46,7 @@ class MiniPongEnv(gym.Env[np.ndarray, int]):
         self.misses = 0
         self.rally_length = 0
         self.episode_reason = "running"
+        self._manual_opponent_action: int | None = None
 
         self.agent_y = 0.0
         self.opponent_y = 0.0
@@ -63,14 +65,13 @@ class MiniPongEnv(gym.Env[np.ndarray, int]):
         self.hits = 0
         self.misses = 0
         self.rally_length = 0
+        self.agent_score = 0
+        self.opponent_score = 0
         self.episode_reason = "running"
 
         self.agent_y = (self.config.height - self.config.paddle_height) / 2
         self.opponent_y = self.agent_y
-        self.ball_x = self.config.width / 2
-        self.ball_y = self.config.height / 2
-        self.ball_vx = float(self._rng.choice([-2, 2]))
-        self.ball_vy = float(self._rng.choice([-1, 1]))
+        self._reset_ball()
         return self._obs(), self._info()
 
     def step(self, action: int) -> tuple[np.ndarray, float, bool, bool, dict[str, Any]]:
@@ -100,8 +101,7 @@ class MiniPongEnv(gym.Env[np.ndarray, int]):
                 reward -= 1.0
                 self.opponent_score += 1
                 self.misses += 1
-                self.episode_reason = "agent_miss"
-                return self._obs(), reward, True, False, self._info()
+                return self._finish_point(reward=reward, scorer="opponent")
 
         if self.ball_vx > 0 and self.ball_x + self.config.ball_size >= right_x:
             if self.opponent_y <= self.ball_y <= self.opponent_y + self.config.paddle_height:
@@ -110,8 +110,7 @@ class MiniPongEnv(gym.Env[np.ndarray, int]):
             else:
                 reward += 1.0
                 self.agent_score += 1
-                self.episode_reason = "opponent_miss"
-                return self._obs(), reward, True, False, self._info()
+                return self._finish_point(reward=reward, scorer="agent")
 
         truncated = self.steps >= self.config.max_steps
         if truncated:
@@ -133,6 +132,16 @@ class MiniPongEnv(gym.Env[np.ndarray, int]):
         )
 
     def _move_opponent(self) -> None:
+        if self._manual_opponent_action is not None:
+            if self._manual_opponent_action == 0:
+                self.opponent_y -= self.config.paddle_speed
+            elif self._manual_opponent_action == 1:
+                self.opponent_y += self.config.paddle_speed
+            self.opponent_y = float(
+                np.clip(self.opponent_y, 0, self.config.height - self.config.paddle_height)
+            )
+            return
+
         center = self.opponent_y + self.config.paddle_height / 2
         target = self.ball_y + self.config.ball_size / 2
         if target > center:
@@ -142,6 +151,34 @@ class MiniPongEnv(gym.Env[np.ndarray, int]):
         self.opponent_y = float(
             np.clip(self.opponent_y, 0, self.config.height - self.config.paddle_height)
         )
+
+    def set_opponent_action(self, action: int | None) -> None:
+        self._manual_opponent_action = action
+
+    def _reset_ball(self) -> None:
+        self.ball_x = self.config.width / 2
+        self.ball_y = self.config.height / 2
+        self.ball_vx = float(self._rng.choice([-2, 2]))
+        self.ball_vy = float(self._rng.choice([-1, 1]))
+
+    def _finish_point(
+        self, reward: float, scorer: str
+    ) -> tuple[np.ndarray, float, bool, bool, dict[str, Any]]:
+        if self.config.score_limit <= 1:
+            self.episode_reason = "opponent_miss" if scorer == "agent" else "agent_miss"
+            return self._obs(), reward, True, False, self._info()
+
+        if (
+            self.agent_score >= self.config.score_limit
+            or self.opponent_score >= self.config.score_limit
+        ):
+            self.episode_reason = "score_limit"
+            return self._obs(), reward, True, False, self._info()
+
+        self.rally_length = 0
+        self.episode_reason = "running"
+        self._reset_ball()
+        return self._obs(), reward, False, False, self._info()
 
     def _obs(self) -> np.ndarray:
         frame = np.zeros((self.config.height, self.config.width), dtype=np.uint8)

--- a/src/play/__init__.py
+++ b/src/play/__init__.py
@@ -1,0 +1,5 @@
+"""Interactive play utilities for MiniPong."""
+
+from src.play.play_minipong import GameController, get_action_from_keys, prepare_agent_obs
+
+__all__ = ["GameController", "get_action_from_keys", "prepare_agent_obs"]

--- a/src/play/play_minipong.py
+++ b/src/play/play_minipong.py
@@ -1,0 +1,198 @@
+"""Interactive pygame interface for MiniPong."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+import torch
+
+from src.envs.minipong import MiniPongConfig, MiniPongEnv
+from src.rl.networks import create_q_network
+
+Side = Literal["left", "right"]
+Action = int
+
+
+@dataclass
+class GameController:
+    left_agent_enabled: bool = False
+    right_agent_enabled: bool = False
+
+    def toggle_agent(self, side: Side) -> bool:
+        if side == "left":
+            self.left_agent_enabled = not self.left_agent_enabled
+            return self.left_agent_enabled
+        self.right_agent_enabled = not self.right_agent_enabled
+        return self.right_agent_enabled
+
+    def get_controller(self, side: Side) -> Literal["agent", "human"]:
+        enabled = self.left_agent_enabled if side == "left" else self.right_agent_enabled
+        return "agent" if enabled else "human"
+
+    def get_status_tag(self, side: Side, debug: bool, policy_name: str) -> str:
+        if self.get_controller(side) == "agent":
+            return f"Policy: {policy_name}" if debug else "AI Agent"
+        if side == "left":
+            return "Keyboard: Up:Q, Down:A"
+        return "Keyboard: Up:P, Down:L"
+
+    def restart(
+        self, env: MiniPongEnv, seed: int | None = None
+    ) -> tuple[np.ndarray, dict[str, Any]]:
+        return env.reset(seed=seed)
+
+
+def get_action_from_keys(side: Side, pressed: set[str]) -> Action:
+    if side == "left":
+        if "q" in pressed:
+            return 0
+        if "a" in pressed:
+            return 1
+        return 2
+    if "p" in pressed:
+        return 0
+    if "l" in pressed:
+        return 1
+    return 2
+
+
+def prepare_agent_obs(obs: np.ndarray, side: Side) -> np.ndarray:
+    if side == "right":
+        return np.ascontiguousarray(np.flip(obs, axis=1))
+    return obs
+
+
+class AgentPolicy:
+    def __init__(self, obs_shape: tuple[int, int, int], checkpoint: str) -> None:
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.network = create_q_network(obs_shape, 3).to(self.device)
+        self.network.eval()
+        self.policy_name = "random"
+
+        if checkpoint:
+            checkpoint_path = Path(checkpoint)
+            data = torch.load(checkpoint_path, map_location=self.device)
+            state = data["model"] if isinstance(data, dict) and "model" in data else data
+            self.network.load_state_dict(state)
+            self.policy_name = checkpoint_path.name
+
+    def act(self, obs: np.ndarray) -> int:
+        if self.policy_name == "random":
+            return int(np.random.randint(3))
+        with torch.no_grad():
+            obs_tensor = torch.tensor(obs[None], dtype=torch.float32, device=self.device)
+            q_values = self.network(obs_tensor)
+            return int(torch.argmax(q_values, dim=1).item())
+
+
+def _pressed_key_names(pygame: Any) -> set[str]:
+    keys = pygame.key.get_pressed()
+    pressed: set[str] = set()
+    keymap = {
+        pygame.K_q: "q",
+        pygame.K_a: "a",
+        pygame.K_p: "p",
+        pygame.K_l: "l",
+    }
+    for code, name in keymap.items():
+        if keys[code]:
+            pressed.add(name)
+    return pressed
+
+
+def run_game(debug: bool, checkpoint: str, left_agent: bool, right_agent: bool) -> None:
+    import pygame
+
+    scale = 6
+    header_height = 80
+    fps = 30
+
+    env = MiniPongEnv(render_mode="rgb_array", config=MiniPongConfig(score_limit=11))
+    obs, info = env.reset(seed=0)
+
+    controller = GameController(left_agent_enabled=left_agent, right_agent_enabled=right_agent)
+    policy = AgentPolicy(obs.shape, checkpoint)
+
+    pygame.init()
+    window_size = (env.config.width * scale, env.config.height * scale + header_height)
+    screen = pygame.display.set_mode(window_size)
+    pygame.display.set_caption("MiniPong")
+    clock = pygame.time.Clock()
+    font = pygame.font.SysFont(None, 26)
+
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_ESCAPE:
+                    running = False
+                elif event.key == pygame.K_r:
+                    obs, info = controller.restart(env, seed=0)
+                elif event.key == pygame.K_a and (event.mod & pygame.KMOD_SHIFT):
+                    controller.toggle_agent("left")
+                elif event.key == pygame.K_l and (event.mod & pygame.KMOD_SHIFT):
+                    controller.toggle_agent("right")
+
+        pressed = _pressed_key_names(pygame)
+
+        left_action = get_action_from_keys("left", pressed)
+        if controller.get_controller("left") == "agent":
+            left_action = int(policy.act(prepare_agent_obs(obs, "left")))
+
+        right_action = get_action_from_keys("right", pressed)
+        if controller.get_controller("right") == "agent":
+            right_action = int(policy.act(prepare_agent_obs(obs, "right")))
+
+        env.set_opponent_action(right_action)
+        obs, _, terminated, truncated, info = env.step(left_action)
+        if terminated or truncated:
+            obs, info = controller.restart(env, seed=0)
+
+        frame = env.render()
+        surface = pygame.surfarray.make_surface(np.transpose(frame, (1, 0, 2)))
+        surface = pygame.transform.scale(
+            surface, (env.config.width * scale, env.config.height * scale)
+        )
+
+        screen.fill((0, 0, 0))
+        screen.blit(surface, (0, header_height))
+
+        score_text = f"Left {info['agent_score']} : {info['opponent_score']} Right"
+        screen.blit(font.render(score_text, True, (255, 255, 255)), (10, 10))
+
+        left_tag = controller.get_status_tag("left", debug, policy.policy_name)
+        right_tag = controller.get_status_tag("right", debug, policy.policy_name)
+        screen.blit(font.render(left_tag, True, (255, 255, 255)), (10, 42))
+        right_surface = font.render(right_tag, True, (255, 255, 255))
+        screen.blit(right_surface, (window_size[0] - right_surface.get_width() - 10, 42))
+
+        pygame.display.flip()
+        clock.tick(fps)
+
+    pygame.quit()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Play MiniPong interactively")
+    parser.add_argument("--checkpoint", default="", help="Path to trained checkpoint (.pt)")
+    parser.add_argument("--debug", action="store_true", help="Show policy names in status tags")
+    parser.add_argument("--left-agent", action="store_true", help="Start with left side on agent")
+    parser.add_argument("--right-agent", action="store_true", help="Start with right side on agent")
+    args = parser.parse_args()
+
+    run_game(
+        debug=args.debug,
+        checkpoint=args.checkpoint,
+        left_agent=args.left_agent,
+        right_agent=args.right_agent,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_env_minipong_score_limit.py
+++ b/tests/test_env_minipong_score_limit.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from src.envs.minipong import MiniPongConfig, MiniPongEnv
+
+
+def _force_left_miss(env: MiniPongEnv) -> tuple[float, bool, bool, dict[str, object]]:
+    env.ball_vx = -2.0
+    env.ball_x = 0.0
+    env.ball_y = env.config.height - env.config.ball_size
+    _, reward, terminated, truncated, info = env.step(2)
+    return reward, terminated, truncated, info
+
+
+def test_score_limit_one_keeps_single_rally_termination() -> None:
+    env = MiniPongEnv(config=MiniPongConfig(score_limit=1))
+    env.reset(seed=0)
+
+    reward, terminated, truncated, info = _force_left_miss(env)
+
+    assert reward == -1.0
+    assert terminated is True
+    assert truncated is False
+    assert info["episode_reason"] == "agent_miss"
+
+
+def test_score_limit_multi_rally_resets_ball_and_continues() -> None:
+    env = MiniPongEnv(config=MiniPongConfig(score_limit=2))
+    env.reset(seed=0)
+
+    reward, terminated, truncated, info = _force_left_miss(env)
+
+    assert reward == -1.0
+    assert terminated is False
+    assert truncated is False
+    assert info["opponent_score"] == 1
+    assert info["episode_reason"] == "running"
+    assert env.ball_x == env.config.width / 2
+    assert env.ball_y == env.config.height / 2
+
+    reward, terminated, _, info = _force_left_miss(env)
+    assert reward == -1.0
+    assert terminated is True
+    assert info["opponent_score"] == 2
+    assert info["episode_reason"] == "score_limit"

--- a/tests/test_play_minipong.py
+++ b/tests/test_play_minipong.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import numpy as np
+
+from src.envs.minipong import MiniPongConfig, MiniPongEnv
+from src.play.play_minipong import GameController, get_action_from_keys, prepare_agent_obs
+
+
+def test_get_action_from_keys() -> None:
+    assert get_action_from_keys("left", {"q"}) == 0
+    assert get_action_from_keys("left", {"a"}) == 1
+    assert get_action_from_keys("left", set()) == 2
+    assert get_action_from_keys("right", {"p"}) == 0
+    assert get_action_from_keys("right", {"l"}) == 1
+
+
+def test_prepare_agent_obs_flips_right_side() -> None:
+    obs = np.arange(12, dtype=np.uint8).reshape(2, 6, 1)
+    right = prepare_agent_obs(obs, "right")
+    left = prepare_agent_obs(obs, "left")
+
+    assert np.array_equal(left, obs)
+    assert np.array_equal(right[:, :, 0], np.fliplr(obs[:, :, 0]))
+
+
+def test_game_controller_status_and_restart() -> None:
+    controller = GameController()
+    assert controller.get_controller("left") == "human"
+    assert (
+        controller.get_status_tag("left", debug=False, policy_name="random")
+        == "Keyboard: Up:Q, Down:A"
+    )
+
+    controller.toggle_agent("left")
+    assert controller.get_controller("left") == "agent"
+    assert controller.get_status_tag("left", debug=False, policy_name="random") == "AI Agent"
+    assert (
+        controller.get_status_tag("left", debug=True, policy_name="checkpoint.pt")
+        == "Policy: checkpoint.pt"
+    )
+
+    env = MiniPongEnv(config=MiniPongConfig(score_limit=3))
+    env.reset(seed=1)
+    env.agent_score = 2
+
+    _, info = controller.restart(env, seed=2)
+    assert info["agent_score"] == 0
+    assert controller.get_controller("left") == "agent"


### PR DESCRIPTION
### Motivation
- Provide an interactive pygame-based MiniPong frontend and support multi-rally play so episodes can continue across points until a configurable `score_limit` is reached.
- Keep backward compatibility with existing RL training/tests by defaulting `score_limit` to `1`.
- Expose small, testable helpers for input mapping and agent observation preparation so play logic can be validated without a display.

### Description
- Added `pygame` to runtime dependencies in `requirements.in`.
- Extended `MiniPongConfig` with `score_limit: int = 1` and implemented multi-rally logic in `src/envs/minipong.py`: introduced `_reset_ball()`, `_finish_point()`, `set_opponent_action()` and tracking of cumulative `agent_score` / `opponent_score`, with `episode_reason` set to `"score_limit"` when the cap is reached; behavior remains identical when `score_limit == 1`.
- Added interactive play package `src/play/` including `src/play/__init__.py` and `src/play/play_minipong.py`, which implement `GameController`, `get_action_from_keys()`, `prepare_agent_obs()`, a simple `AgentPolicy` loader (checkpoint or random), takeover toggles (`Shift+A`, `Shift+L`), two-player keyboard controls (`Q/A` left, `P/L` right), HUD/status tags, and a 30 FPS pygame loop (window created only in `run_game`).
- Added Makefile targets: `play`, `play-debug`, and `play-agent-vs-agent` which run `python -m src.play.play_minipong` with appropriate flags.
- Added focused tests: `tests/test_env_minipong_score_limit.py` to validate multi-rally behavior and backward compatibility, and `tests/test_play_minipong.py` to validate input mapping, obs preparation, and `GameController` helpers (all testable without a display).

### Testing
- Ran static checks and type checks: `make lint && make typecheck` (both passed).
- Ran unit tests for the new functionality: `pytest -q tests/test_env_minipong_score_limit.py tests/test_play_minipong.py` (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fad95b0408328b1f420b9745160f0)