### PR TITLE
Fix GameController API mismatches from Gate 0 feedback

### DIFF
--- a/src/envs/minipong.py
+++ b/src/envs/minipong.py
@@ -68,6 +68,7 @@ class MiniPongEnv(gym.Env[np.ndarray, int]):
         self.agent_score = 0
         self.opponent_score = 0
         self.episode_reason = "running"
+        self._manual_opponent_action = None
 
         self.agent_y = (self.config.height - self.config.paddle_height) / 2
         self.opponent_y = self.agent_y

--- a/tests/test_env_minipong_smoke.py
+++ b/tests/test_env_minipong_smoke.py
@@ -9,3 +9,31 @@ def test_minipong_smoke() -> None:
     assert obs.shape == (84, 84, 1)
     assert obs.dtype.name == "uint8"
     assert "hits" in info
+
+
+def test_set_opponent_action_manual_and_restore_ai() -> None:
+    env = MiniPongEnv()
+    env.reset(seed=0)
+    start_y = env.opponent_y
+
+    env.set_opponent_action(0)
+    env.step(2)
+    assert env.opponent_y < start_y
+
+    manual_y = env.opponent_y
+    env.set_opponent_action(None)
+    env.ball_y = env.opponent_y + 40
+    env.step(2)
+    assert env.opponent_y > manual_y
+
+
+def test_reset_clears_manual_opponent_action() -> None:
+    env = MiniPongEnv()
+    env.reset(seed=0)
+    env.set_opponent_action(0)
+    env.reset(seed=1)
+
+    start_y = env.opponent_y
+    env.ball_y = env.opponent_y + 40
+    env.step(2)
+    assert env.opponent_y > start_y

--- a/tests/test_play_minipong.py
+++ b/tests/test_play_minipong.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 
-from src.envs.minipong import MiniPongConfig, MiniPongEnv
 from src.play.play_minipong import GameController, get_action_from_keys, prepare_agent_obs
 
 
@@ -12,6 +11,7 @@ def test_get_action_from_keys() -> None:
     assert get_action_from_keys("left", set()) == 2
     assert get_action_from_keys("right", {"p"}) == 0
     assert get_action_from_keys("right", {"l"}) == 1
+    assert get_action_from_keys("right", set()) == 2
 
 
 def test_prepare_agent_obs_flips_right_side() -> None:
@@ -24,25 +24,25 @@ def test_prepare_agent_obs_flips_right_side() -> None:
 
 
 def test_game_controller_status_and_restart() -> None:
-    controller = GameController()
+    controller = GameController(debug=True, checkpoint_path="models/checkpoint.pt")
     assert controller.get_controller("left") == "human"
-    assert (
-        controller.get_status_tag("left", debug=False, policy_name="random")
-        == "Keyboard: Up:Q, Down:A"
-    )
+    assert controller.get_status_tag("left") == "Keyboard: Up:Q, Down:A"
 
     controller.toggle_agent("left")
     assert controller.get_controller("left") == "agent"
-    assert controller.get_status_tag("left", debug=False, policy_name="random") == "AI Agent"
-    assert (
-        controller.get_status_tag("left", debug=True, policy_name="checkpoint.pt")
-        == "Policy: checkpoint.pt"
-    )
+    assert controller.get_status_tag("left") == "Policy: checkpoint.pt"
 
-    env = MiniPongEnv(config=MiniPongConfig(score_limit=3))
-    env.reset(seed=1)
-    env.agent_score = 2
+    nodebug = GameController(left_agent_enabled=True)
+    assert nodebug.get_status_tag("left") == "AI Agent"
 
-    _, info = controller.restart(env, seed=2)
-    assert info["agent_score"] == 0
+
+def test_game_controller_restart_preserves_toggles() -> None:
+    controller = GameController(left_agent_enabled=True, right_agent_enabled=False)
+    controller.restart()
     assert controller.get_controller("left") == "agent"
+    assert controller.get_controller("right") == "human"
+
+
+def test_game_controller_debug_random_policy_name() -> None:
+    controller = GameController(left_agent_enabled=True, debug=True)
+    assert controller.get_status_tag("left") == "Policy: random"


### PR DESCRIPTION
### Motivation
- The Gate 0 adversarial review reported mismatches in the `GameController` public API that break interactive play and tests and must be corrected.
- There was a small environment state-leak where manual opponent actions persisted across resets which could confuse agent/human takeover behavior.
- Tests were missing coverage for manual opponent control and the right-side STAY action which were requested in the feedback file.

### Description
- Update `GameController` to accept `debug` and `checkpoint_path` in its constructor and store them as instance attributes.
- Change `get_status_tag(side)` to a single-argument method that uses `self.debug` and `self.checkpoint_path` to derive the displayed policy name and returns human/agent tags per spec.
- Change `restart()` to take zero arguments and not call `env.reset()` so the caller remains responsible for environment resets, and update `run_game()` call sites accordingly.
- Clear `self._manual_opponent_action` inside `MiniPongEnv.reset()` to prevent manual-action leakage between episodes.
- Use `torch.load(..., weights_only=True)` when loading checkpoints in `AgentPolicy` to follow the security requirement.
- Add/adjust tests to cover `set_opponent_action` manual override and restore, right-side STAY action, `GameController` debug/random policy labeling, and `restart()` preserving toggle state.

### Testing
- Ran `make lint` which passed (`ruff` checks succeeded). 
- Ran `make typecheck` which passed under `mypy` after installing `types-PyYAML` to satisfy missing stubs. 
- Ran `pytest` for the play and env smoke tests with `pytest tests/test_play_minipong.py tests/test_env_minipong_smoke.py` and observed all tests passing (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fbcec46cc832897674743c325815d)