### PR TITLE
review-prompts: add claim-vs-enforcement check (rbe/security/adversarial)

### DIFF
--- a/packages/review-prompts/adversarial_review.md
+++ b/packages/review-prompts/adversarial_review.md
@@ -63,6 +63,10 @@ Behavior that contradicts specs even if tests pass:
 - **Environment variable dependencies.** Silent failure without required env vars
 - **Version mismatches.** Requirements specifying one version but code using APIs from another
 
+### 6. Unenforced Claims (the spec/code promises what nothing enforces)
+
+Hunt for properties that are ASSERTED but not ENFORCED. A name, annotation, docstring, or contract that claims `read-only` / `immutable` / `idempotent` / `exactly-once` / `atomic` / `validated` is only true if something MAKES it true. For each such claim in the diff, find the enforcement or flag the lie. A `SELECT` or a `get_*` name is not read-only (volatile functions, writable CTEs, the writable connection role defeat it); a `readOnlyHint: true` annotation enforces nothing; "validated" with the validator on a different path validates nothing. Also apply this ACROSS a document: when reviewing a spec/contract, a change to one section (a type made conditional, an invariant relaxed) must be reconciled at EVERY place it is referenced (test matrices, DDL, end-to-end scenarios, other type docstrings) — trace the changed concept everywhere and flag any section left contradicting it.
+
 ## Review Output Format
 
 Your output is **hybrid** — two parts, both written to your .jsonl file at `{output_path}`.

--- a/packages/review-prompts/rbe_review.md
+++ b/packages/review-prompts/rbe_review.md
@@ -56,6 +56,12 @@ This matters because both humans and agents have finite attention. Well-defined 
   - Typed errors and exceptions: `ValidationError(field, reason)` > generic `ValueError`
   - Domain-specific types that make boundaries machine-checkable at every level
 
+## Claims Must Be Enforced (the name is a contract)
+
+A name, annotation, docstring, flag, or type that CLAIMS a property — `readOnlyHint`, `immutable`, `idempotent`, `atomic`, `validated`, `*_readonly`, `frozen`, `exactly_once`, `append_only` — is a contract. RBE's litmus has a second half: not just "what is this responsible for?" but "what MAKES that true?". For every claimed property in the diff, either point to the concrete enforcement (a read-only DB role, a validator that runs, a UNIQUE constraint, a transaction boundary, a type that makes the bad state unrepresentable) or flag the claim as UNBACKED — a name that promises what the system does not enforce is a lie, and that is a Critical RBE defect.
+
+Do NOT accept the shape of the code as proof: a `SELECT`, a `get_*`/`read_*` name, or a `readOnlyHint` annotation does NOT prove read-only — volatile functions, writable CTEs, locks, and the executing role's write capability all defeat it. The guarantee lives in the enforcement, never the name. When you cannot find the enforcement, that is the finding.
+
 ## Output Format
 
 **FileReviewOutcome files must be EXACT paths** — one per file in the diff. No glob patterns (`*`, `?`), no directory paths (`src/`), no "(N files)" summaries. The validator will reject them.

--- a/packages/review-prompts/security_review.md
+++ b/packages/review-prompts/security_review.md
@@ -70,6 +70,10 @@ Assess severity based on THIS system's threat model, not generic rankings.
 - **Copy-paste vulnerabilities.** Deprecated API usage or patterns from older library versions
 - **Subprocess with shell=True.** LLMs default to shell=True more often than necessary
 
+### 8. Unenforced Security Claims (claim-vs-enforcement)
+
+For every property the code or spec CLAIMS that carries a security guarantee — read-only, sandboxed, isolated, validated, least-privilege, encrypted, tenant-scoped, immutable, append-only — verify there is a NAMED ENFORCEMENT MECHANISM that makes it true, not just an annotation/name asserting it. A `readOnlyHint` tool that runs over a writable connection, a "validated" input with no validator on the actual code path, a "sandboxed" exec with no sandbox, an "isolated" tenant on a shared role — these are claims the system cannot keep, and an attacker relies on exactly that gap. If you cannot point to the enforcement (the read-only role, the running validator, the constraint, the boundary), flag the unbacked claim as a vulnerability.
+
 ## What NOT to Flag
 
 - `random` module usage for non-security purposes (seeds, environment randomness) — assess whether it's a cryptographic context


### PR DESCRIPTION
**Fix-forward for the readOnlyHint miss.** Multiple seven-paradigm panels + rounds reviewed the study-lifecycle spec and never flagged that `readOnlyHint` is a self-declared annotation with no enforcement — some "read-only" tools (e.g. one that runs `SET ROLE` / arbitrary SQL over a writable connection) claim a property the system can't keep.

Root cause: no paradigm was tasked to challenge **claim-vs-enforcement**. This adds that obligation to the three rubrics most responsible for it:

- **rbe** — "Claims Must Be Enforced (the name is a contract)": the RBE litmus gains its second half ("what MAKES it true?"); a `SELECT`/`get_*`/`readOnlyHint` is not proof of read-only.
- **security** — "Unenforced Security Claims": a guarantee nothing enforces is the exact gap an attacker uses.
- **adversarial** — "Unenforced Claims" + a cross-document corollary: a change to one spec section must be reconciled at every place the concept is referenced (test matrix, DDL, E2E, other docstrings) — the other failure mode from the same review (an audit-model change that contradicted T-01 / the type docstring / the DDL / the E2E, caught only by a late whole-document pass).

The companion durable rule (whole-document consistency pass + the claim-vs-enforcement obligation) is in the global convergence standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)